### PR TITLE
route for frontpage

### DIFF
--- a/backend/src/routes/courseRoutes.mjs
+++ b/backend/src/routes/courseRoutes.mjs
@@ -4,6 +4,9 @@ import { verifyToken, isTeacher } from '../middlewares/verifyToken.mjs';
 
 const router = express.Router();
 
+// Route to get all courses in frontpage- No token required for public access
+router.get('/public', getAllCourses);
+
 // Route to get all courses
 router.get('/', verifyToken, getAllCourses);
 


### PR DESCRIPTION
Added a /public route in the courseRoutes file. This route will be used in the frontend to display all courses on the front page for public view. No token is required to view these courses.