### PR TITLE
Set text color in form input fields to dark gray (#333) for better readabilty

### DIFF
--- a/src/components/layout/SignIn.module.css
+++ b/src/components/layout/SignIn.module.css
@@ -64,6 +64,7 @@
     box-sizing: border-box;
     font-size: 14px;
     background-color: white;
+    color: #333; 
 }
 
 .closingSection {

--- a/src/components/layout/Signup.module.css
+++ b/src/components/layout/Signup.module.css
@@ -64,6 +64,7 @@
     box-sizing: border-box;
     font-size: 14px;
     background-color: white;
+    color: #333; 
 }
 
 .closingSection {


### PR DESCRIPTION
Set the text color in form input fields to dark gray (#333) to ensure readability against the white background. No text color was defined before, which could lead to unintended color inheritance depending on the surrounding styles. See before and after screenshot:

<img width="1697" alt="Screenshot 2024-08-24 at 1 35 04 AM" src="https://github.com/user-attachments/assets/e33e09ed-8582-4309-a35f-a01429d43ef2">
<img width="1697" alt="Screenshot 2024-08-24 at 1 35 56 AM" src="https://github.com/user-attachments/assets/bfbb6095-490b-47b2-805d-5625f4750d00">
